### PR TITLE
microsoftwindowsremotemanagement: Bugfix - Use Vault API instead of filesystem to create attachments

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR Windows Remote Management
-Copyright (c) 2018-2022 Splunk Inc.
+Copyright (c) 2018-2023 Splunk Inc.
 
 Third-party Software Attributions:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Windows Remote Management
 
 Publisher: Splunk  
-Connector Version: 2.2.5  
+Connector Version: 2.2.6  
 Product Vendor: Microsoft  
 Product Name: Windows Remote Management  
 Product Version Supported (regex): ".\*"  

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Connector Version: 2.2.5
 Product Vendor: Microsoft  
 Product Name: Windows Remote Management  
 Product Version Supported (regex): ".\*"  
-Minimum Product Version: 6.1.1 
+Minimum Product Version: 6.1.1  
 
 This app integrates with the Windows Remote Management service to execute various actions
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Connector Version: 2.2.5
 Product Vendor: Microsoft  
 Product Name: Windows Remote Management  
 Product Version Supported (regex): ".\*"  
-Minimum Product Version: 5.5.0  
+Minimum Product Version: 6.1.1 
 
 This app integrates with the Windows Remote Management service to execute various actions
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This app integrates with the Windows Remote Management service to execute variou
 
 [comment]: # ""
 [comment]: # "    File: README.md"
-[comment]: # "    Copyright (c) 2018-2022 Splunk Inc."
+[comment]: # "    Copyright (c) 2018-2023 Splunk Inc."
 [comment]: # "    "
 [comment]: # "    Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)"
 [comment]: # ""

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,6 +1,6 @@
 [comment]: # ""
 [comment]: # "    File: README.md"
-[comment]: # "    Copyright (c) 2018-2022 Splunk Inc."
+[comment]: # "    Copyright (c) 2018-2023 Splunk Inc."
 [comment]: # "    "
 [comment]: # "    Licensed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)"
 [comment]: # ""

--- a/parse_callbacks.py
+++ b/parse_callbacks.py
@@ -19,7 +19,6 @@
 # in any specific manner
 import base64
 import json
-import tempfile
 from builtins import str
 from collections import OrderedDict
 
@@ -453,13 +452,7 @@ def decodeb64_add_to_vault(action_result, response, container_id, file_name):
     b64string = response.std_out
 
     try:
-        if hasattr(Vault, 'create_attachment'):
-            resp = Vault.create_attachment(base64.b64decode(b64string), container_id, file_name=file_name)
-        else:
-            tmp_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, dir='/opt/phantom/vault/tmp')
-            tmp_file.write(base64.b64decode(b64string))
-            tmp_file.close()
-            resp = Vault.add_attachment(tmp_file.name, container_id, file_name=file_name)
+        resp = Vault.create_attachment(base64.b64decode(b64string), container_id, file_name=file_name)
     except Exception as e:
         return action_result.set_status(
             phantom.APP_ERROR, "Error adding file to vault", e

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 * Use the Vault API to create temporary files, instead of manual filesystem access [PAPP-32449]
 * Update `min_phantom_version` to 6.1.1
-* Remove `requests` dependency, instead using the one built into the platform
+* Remove `requests` dependency, using the one built into the platform instead

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,5 @@
 * Use the Vault API to create temporary files, instead of manual filesystem access [PAPP-32449]
 * Update `min_phantom_version` to 6.1.1
 * Remove `requests` dependency, using the one built into the platform instead
+* Suppress "progress" output from PowerShell, preventing actions from wrongly being marked as failed
+* Improve Unicode parsing to prevent errors

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+* Use the Vault API to create temporary files, instead of manual filesystem access [PAPP-32449]
+* Update `min_phantom_version` to 6.1.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 * Use the Vault API to create temporary files, instead of manual filesystem access [PAPP-32449]
 * Update `min_phantom_version` to 6.1.1
+* Remove `requests` dependency, instead using the one built into the platform

--- a/winrm.json
+++ b/winrm.json
@@ -14,7 +14,7 @@
     "utctime_updated": "2023-12-05T12:42:47.000000Z",
     "package_name": "phantom_winrm",
     "main_module": "winrm_connector.py",
-    "min_phantom_version": "5.5.0",
+    "min_phantom_version": "6.1.1",
     "fips_compliant": true,
     "python_version": "3",
     "latest_tested_versions": [

--- a/winrm.json
+++ b/winrm.json
@@ -3340,10 +3340,6 @@
                 "input_file": "wheels/shared/pywinrm-0.4.3-py2.py3-none-any.whl"
             },
             {
-                "module": "requests",
-                "input_file": "wheels/py3/requests-2.31.0-py3-none-any.whl"
-            },
-            {
                 "module": "requests_ntlm",
                 "input_file": "wheels/py3/requests_ntlm-1.2.0-py3-none-any.whl"
             },

--- a/winrm.json
+++ b/winrm.json
@@ -10,7 +10,7 @@
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2018-2023 Splunk Inc.",
-    "app_version": "2.2.5",
+    "app_version": "2.2.6",
     "utctime_updated": "2023-12-05T12:42:47.000000Z",
     "package_name": "phantom_winrm",
     "main_module": "winrm_connector.py",

--- a/winrm_connector.py
+++ b/winrm_connector.py
@@ -319,7 +319,7 @@ class WindowsRemoteManagementConnector(BaseConnector):
             else:
                 resp = self._session.run_cmd(cmd, args)
         except UnicodeDecodeError:
-            return action_result.set_status(phantom.APP_ERROR, "Error running command: {}".format(consts.WINRM_UNICODE_ERR_MSG))
+            return action_result.set_status(phantom.APP_ERROR, "Error running command: {}".format(consts.WINRM_UNICODE_ERROR_MESSAGE))
         except Exception as e:
             return action_result.set_status(phantom.APP_ERROR,
                 "Error running command: {}".format(unquote(self._get_error_message_from_exception(e))))
@@ -372,7 +372,7 @@ class WindowsRemoteManagementConnector(BaseConnector):
                     script = UnicodeDammit(script).unicode_markup
                 resp = self._session.run_ps(script)
         except UnicodeDecodeError:
-            return action_result.set_status(phantom.APP_ERROR, "Error running PowerShell script: {}".format(consts.WINRM_UNICODE_ERR_MSG))
+            return action_result.set_status(phantom.APP_ERROR, "Error running PowerShell script: {}".format(consts.WINRM_UNICODE_ERROR_MESSAGE))
         except Exception as e:
             return action_result.set_status(phantom.APP_ERROR,
                 "Error running PowerShell script: {}".format(self._get_error_message_from_exception(e)))

--- a/winrm_connector.py
+++ b/winrm_connector.py
@@ -319,7 +319,7 @@ class WindowsRemoteManagementConnector(BaseConnector):
             else:
                 resp = self._session.run_cmd(cmd, args)
         except UnicodeDecodeError:
-            return action_result.set_status(phantom.APP_ERROR, "Error running command: {}".format(consts.WINRM_UNICODE_ERROR_MESSAGE))
+            return action_result.set_status(phantom.APP_ERROR, "Error running command: {}".format(consts.WINRM_UNICODE_ERR_MSG))
         except Exception as e:
             return action_result.set_status(phantom.APP_ERROR,
                 "Error running command: {}".format(unquote(self._get_error_message_from_exception(e))))
@@ -372,7 +372,7 @@ class WindowsRemoteManagementConnector(BaseConnector):
                     script = UnicodeDammit(script).unicode_markup
                 resp = self._session.run_ps(script)
         except UnicodeDecodeError:
-            return action_result.set_status(phantom.APP_ERROR, "Error running PowerShell script: {}".format(consts.WINRM_UNICODE_ERROR_MESSAGE))
+            return action_result.set_status(phantom.APP_ERROR, "Error running PowerShell script: {}".format(consts.WINRM_UNICODE_ERR_MSG))
         except Exception as e:
             return action_result.set_status(phantom.APP_ERROR,
                 "Error running PowerShell script: {}".format(self._get_error_message_from_exception(e)))

--- a/winrm_connector.py
+++ b/winrm_connector.py
@@ -358,7 +358,7 @@ class WindowsRemoteManagementConnector(BaseConnector):
                 if len(resp.std_err):
                     resp.std_err = self._session._clean_error_msg(resp.std_err)
                     if isinstance(resp.std_err, bytes):
-                        resp.std_err = resp.std_err.decode('UTF-8')
+                        resp.std_err = resp.std_err.decode('UTF-8', errors='ignore')
             elif async_:
                 encoded_ps = b64encode(script.encode('utf_16_le')).decode('ascii')
                 shell_id = self._protocol.open_shell()
@@ -850,6 +850,8 @@ class WindowsRemoteManagementConnector(BaseConnector):
                 self._sanitize_string(file_path), new_policy_str, set_policy_str
             ))
 
+        self.debug_print(ps_script)
+
         ret_val = self._run_ps(action_result, ps_script, parse_callback=pc.check_exit_no_data2)
         if phantom.is_fail(ret_val):
             return ret_val
@@ -971,7 +973,7 @@ class WindowsRemoteManagementConnector(BaseConnector):
         path_from = self._handle_py_ver_compat_for_input_str(param['from'])
         path_to = self._handle_py_ver_compat_for_input_str(param['to'])
 
-        ps_script = "& copy {0} {1}".format(
+        ps_script = "$ProgressPreference = 'SilentlyContinue'; & copy {0} {1}".format(
             self._sanitize_string(path_from),
             self._sanitize_string(path_to)
         )
@@ -990,7 +992,7 @@ class WindowsRemoteManagementConnector(BaseConnector):
         file_path = self._handle_py_ver_compat_for_input_str(param['file_path'])
         force_delete = '-Force ' if param.get('force') else ''
 
-        ps_script = "& del {0}{1}".format(
+        ps_script = "$ProgressPreference = 'SilentlyContinue'; & del {0}{1}".format(
             force_delete,
             self._sanitize_string(file_path)
         )

--- a/winrm_consts.py
+++ b/winrm_consts.py
@@ -13,6 +13,7 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 APPLOCKER_BASE_SCRIPT = """
+$ProgressPreference = 'SilentlyContinue'
 Import-Module AppLocker
 """
 

--- a/winrm_consts.py
+++ b/winrm_consts.py
@@ -87,7 +87,7 @@ $d = "{}"
 [Convert]::ToBase64String([IO.File]::ReadAllBytes($d))
 """
 
-WINRM_UNICODE_ERR_MSG = "Invalid unicode detected"
+WINRM_UNICODE_ERROR_MESSAGE = "Invalid unicode detected"
 
 # Constants relating to '_validate_integer'
 WINRM_ERROR_INVALID_INT = 'Please provide a valid {msg} integer value in the "{param}"'

--- a/winrm_consts.py
+++ b/winrm_consts.py
@@ -13,7 +13,6 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 APPLOCKER_BASE_SCRIPT = """
-$ProgressPreference = 'SilentlyContinue'
 Import-Module AppLocker
 """
 

--- a/winrm_consts.py
+++ b/winrm_consts.py
@@ -87,7 +87,7 @@ $d = "{}"
 [Convert]::ToBase64String([IO.File]::ReadAllBytes($d))
 """
 
-WINRM_UNICODE_ERROR_MESSAGE = "Invalid unicode detected"
+WINRM_UNICODE_ERR_MSG = "Invalid unicode detected"
 
 # Constants relating to '_validate_integer'
 WINRM_ERROR_INVALID_INT = 'Please provide a valid {msg} integer value in the "{param}"'


### PR DESCRIPTION
Please ensure your pull request (PR) adheres to the following guidelines:

- Please refer to our contributing documentation for any questions on submitting a pull request, link: [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md)

## Pull Request Checklist

#### Please check if your PR fulfills the following requirements:
- [x] Testing of all the changes has been performed (for bug fixes / features)
- [x] The manual_readme_content.md has been reviewed and added / updated if needed (for bug fixes / features)
- [x] Use the following format for the PR description: `<App Name>: <PR Type> - <PR Description>`
- [x] Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.
- [x] Verify all checks are passing.
- [x] Do NOT use the `next` branch of the forked repo. Create separate feature branch for raising the PR.
- [x] Do NOT submit updates to dependencies unless it fixes an issue.
## Pull Request Type

#### Please check the type of change your PR introduces:
- [ ] New App
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation
- [ ] Other (please describe):

## Security Considerations (REQUIRED)
- [X] If you are exposing any endpoints using a [REST handler](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers),
  please document them in the `manual_readme_content.md`.
  - N/A
- [X] If this is a new connector or you are adding new actions
    - N/A
- [X] Are you introducing any new cryptography modules? If yes, please elaborate their purpose:
  - N/A
- [X] Are you are accessing the file system? If yes, please verify that you are only accessing paths returned through
the [Vault](https://docs.splunk.com/Documentation/SOARonprem/5.2.1/DevelopApps/AppDevAPIRef#Vault) API.
  - The purpose of this update is to bring this app into compliance with this rule.
- [X] Are you are marking code to be ignored by Semgrep with [`nosemgrep`](https://semgrep.dev/docs/ignoring-files-folders-code/#ignoring-code-through-nosemgrep)?
If yes, please provide justification in an additional comment next to the ignored code.
  - N/A



## Release Notes (REQUIRED)
* Use the Vault API to create temporary files, instead of manual filesystem access [PAPP-32449]
* Update `min_phantom_version` to 6.1.1
* Remove the `requests` dependency, and use the one built into Phantom instead
* Suppress the "progress" output from PowerShell scripts. This output was causing actions to incorrectly be marked as failed on some Windows configurations, including the internal testing environment.
* Improve parsing of Unicode output from PowerShell, to prevent errors. Characters that cannot be decoded are now backslash-escaped, instead of throwing an exception. This also fixes a flaky test.

## What is the current behavior? (OPTIONAL)
- App checks for the existence of the `Vault.create_attachment` library method. If available, it uses it to save a file to Vault.
    - If unavailable, it manually creates the file on disk using a hardcoded `/opt/phantom` path, then uses `Vault.add_attachment` to save it to Vault. This is not an acceptable way to access the filesystem.
- If PowerShell's "progress" output is enabled globally on the remote system, actions that run a PowerShell script will receive success messages via the standard error stream. This causes actions to fail, as stderr is expected to be empty.
- If output from PowerShell contains characters that can't be decoded by UTF-8, an exception is thrown and the action fails.

## What is the new behavior? (OPTIONAL)
- The app no longer checks for the existence of `Vault.create_attachment`, and instead simply uses it to upload the file. 
    - This is safe to do with no pre-check needed, because the app targets SOAR 6.1.1. `Vault.create_attachment` was introduced in 4.x.
- PowerShell scripts are prefaced with `$ProgressPreference = 'SilentlyContinue'`, which prevents status information from being printed to standard error and crashing the action.
- Invalid characters in PowerShell output are backslash-escaped, to prevent exceptions.

---
Thanks for contributing!
